### PR TITLE
Update wrong company information

### DIFF
--- a/data/events.yml
+++ b/data/events.yml
@@ -15,7 +15,7 @@
 - eventId: 20241202-bejug
   eventName: "\"Java Evolutions\" with Badr Kacimi and Simon Ritter"
   eventUrl: https://www.meetup.com/belgian-java-user-group/events/304395041/
-  location: Colruyt, Zwijnaarde
+  location: Colruyt Group, Zwijnaarde
   date: 2024-12-02
   talks:
     - title: "Java Evolutions"


### PR DESCRIPTION
Colruyt Group asked to use the correct company name that is organizing. 
This is Colruyt Group, not Colruyt Laagstse prijzen.

This pull request includes a minor update to the `data/events.yml` file. The change corrects the location name for an event.

* [`data/events.yml`](diffhunk://#diff-fe1a9027609c6cd490164da2985c08a8656a632c99f4ad391f1788625718dd6bL18-R18): Updated the location from "Colruyt, Zwijnaarde" to "Colruyt Group, Zwijnaarde" for the event on December 2, 2024.