### PR TITLE
Bump jbake

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <inceptionYear>2022</inceptionYear>
 
   <properties>
-    <version.org.jbake>2.7.0-rc.6</version.org.jbake>
+    <version.org.jbake>2.7.0-rc.7</version.org.jbake>
   </properties>
 
   <build>


### PR DESCRIPTION
Fixes the following issue with Apple Silicon chips

[...] Unable to execute or load jffi binary stub from [...] 
[...] (fat file, but missing compatible architecture (have 'i386,x86_64', need 'arm64e' or 'arm64')) [...]